### PR TITLE
Add missing elements and styling

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -37,6 +37,22 @@ h4 {
     color: #2c3643;
 }
 
+h5 {
+    font-family: Open Sans, sans-serif;
+    font-size: 1.314em;
+    font-weight: 400;
+    letter-spacing: 0;
+    color: #2c3643;
+}
+
+h6 {
+    font-family: Open Sans, sans-serif;
+    font-size: 1.214em;
+    font-weight: 400;
+    letter-spacing: 0;
+    color: #2c3643;
+}
+
 p {
     font-family: Open Sans, sans-serif;
     line-height: 1.5;

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -61,6 +61,15 @@ p {
     color: #2c3643;
 }
 
+ul, li {
+    font-family: Open Sans, sans-serif;
+    line-height: 1.5;
+    font-weight: 400;
+    letter-spacing: 0;
+    color: #2c3643;
+    text-align: left;
+}
+
 blockquote {
     border-left: 15px solid #2c3643;
     padding: 0 0 0 5px;

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -61,6 +61,11 @@ p {
     color: #2c3643;
 }
 
+blockquote {
+    border-left: 15px solid #2c3643;
+    padding: 0 0 0 5px;
+}
+
 a {
     text-decoration: none;
     color: #2c3644;

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -61,7 +61,7 @@ p {
     color: #2c3643;
 }
 
-ul, li {
+ul, ol {
     font-family: Open Sans, sans-serif;
     line-height: 1.5;
     font-weight: 400;


### PR DESCRIPTION
**Problem**
If you spin up a new Ghost blog, there are some default posts using elements that this theme doesn't cater for. The most noticeable ones are the _ul_ and _ol_ elements, then the _blockquote_ element. This 'prevents' someone from quickly picking up this theme, as the theme initially feels disjointed and incomplete.

**Solution**
This PR adds in the elements and styling (keeping with the theme) so it's 'more useable' by someone just applying the theme and starting their blog. It also expands the useable elements available to the writer as they now fit with the rest of the theme.

<hr>

The only real 'styling' applied is the _blockquote_ element, which I'm happy to change up if you'd like it styled differently. Everything else is effectively the same as other elements, just tidied up or applied.